### PR TITLE
Fix deprecated macOS version check

### DIFF
--- a/Formula/liquidsoap.rb
+++ b/Formula/liquidsoap.rb
@@ -134,7 +134,7 @@ class Liquidsoap < Formula
   homepage 'http://liquidsoap.fm/'
   sha256 '03990cbe21dc41b0aeeda60fcaaf5c2c48707c418724fe88abc1c57a5fa15ef5'
 
-  unless MacOS.snow_leopard? or MacOS.lion? or MacOS.mountain_lion?
+  unless MacOS.version >= :snow_leopard
     onoe 'Sorry!'
     onoe 'We currently does not support MacOSX older than 10.6, '
     onoe 'try old Macports way described here -> http://savonet.sourceforge.net/macports.html'


### PR DESCRIPTION
During the install of the formula I have been getting the following warning:

```
Warning: Calling MacOS.snow_leopard? is deprecated!
Use 'MacOS.version >= :snow_leopard' instead.
/usr/local/Homebrew/Library/Taps/drfill/homebrew-liquidsoap/Formula/liquidsoap.rb:137:in `<class:Liquidsoap>'
Please report this to the drfill/liquidsoap tap!
```

This patch addresses the concern mentioned above.